### PR TITLE
챌린지 정책 관련 수정 (당일 참여 가능, 하루 작성 가능한 게시글 수 제한)

### DIFF
--- a/server/models/challenge.js
+++ b/server/models/challenge.js
@@ -35,6 +35,9 @@ const ChallengeSchema = new mongoose.Schema(
         likeUsers: {
             type: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Users' }],
         },
+        madeBy: {
+            type: mongoose.Schema.Types.ObjectId,
+        },
     },
 
     { timestamps: true } // createdAt, updatedAt 으로 Date형 객체 입력

--- a/server/modules/calcProperty.js
+++ b/server/modules/calcProperty.js
@@ -57,7 +57,7 @@ module.exports = {
             const end = new Date(cur); //    3/8:15:00
 
             const dateDiff = Math.ceil((end.getTime() - start.getTime()) / (1000 * 3600 * 24));
-            if (dateDiff < 0) {
+            if (dateDiff <= 0) {
                 i.status = 1; //시작 전
             } else if (dateDiff > 30) {
                 i.status = 2; //완료


### PR DESCRIPTION
1.  유저들의 이탈을 막기 위하여 당일에 참여와 인증이 가능하도록 API 변경

2. 포인트의 획득을 위하여 하루에 게시글을 수도 없이 생성하는 행위를 방지하기 위하여 
하루 작성 가능한 게시글 수를 제한 
