### PR TITLE
🐛 랭킹 조회시, 닉네임이 중복된 경우 동명이인의 정보를 가져오는 현상 수정

### DIFF
--- a/server/controller/user.js
+++ b/server/controller/user.js
@@ -184,12 +184,13 @@ async function checkLogin(req, res) {
     });
 }
 
+// 유저 랭킹 정보 불러오기
 async function callUserRanking(req, res) {
     const { user } = res.locals; // user object
     const { length } = req.query;
 
     let RankingList;
-    RankingList = await User.find({}, { _id: 1, nickname: 1, proofCnt: 1 })
+    RankingList = await User.find({}, { _id: 1, email: 1, nickname: 1, proofCnt: 1 })
         .sort({ proofCnt: -1 })
         .lean();
 
@@ -230,7 +231,7 @@ async function callUserRanking(req, res) {
         RankingList = RankingList.slice(0, length);
         res.status(200).json({ RankingList });
     } else {
-        let me = RankingList.find((el) => el.nickname == user.nickname);
+        let me = RankingList.find((el) => el.email == user.email);
         RankingList = RankingList.slice(0, length);
         res.status(200).json({ me, RankingList });
     }


### PR DESCRIPTION
[재현 방법]

1. 메인 페이지에 접근한다.
2. 랭킹 항목에서, [더보기] 버튼을 선택한다.
3. 닉네임이 중복되는 경우, 내가 아닌 다른 사용자의 내용이 표시된다.

[기대 결과]
닉네임이 동일하지만, 나의 id 또는 이메일 정보와 일치하는 값을 불러온다.